### PR TITLE
Bump to 0.4.0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "idr-py" %}
-{% set version = "0.4.0.dev3" %}
+{% set version = "0.4.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 88e05f47c054c44c03fff6c8f78d0f313f206cb28bc6348f27c6b1ef36a8d395
+  sha256: e355a7636e5f6883d19955dd3d3edfc4de263040796fad593f4676e49e8a413c
 
 build:
   noarch: python


### PR DESCRIPTION
We never got round to releasing the non-dev version